### PR TITLE
Documentation and error fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,5 +50,5 @@ Only `urls` is required - all other options are optional. If you don't want to u
 | ---------------- | ------------------ | -------------------- |-------------  |
 | enabled          | `boolean`          | `mix.inProduction()` | If generating Critical CSS should be enabled |
 | paths            | `object`           | `{}`                 | Takes 2 arguments `base` ( src-url ) and `templates` ( folder where critical css files should be written )
-| urls             | `array`            | `[]`                 | An array of url objects, each with a src and dest: `{ src: 'http://example.com', dest: 'index_critical.min.css' }` |
+| urls             | `array`            | `[]`                 | An array of url objects, each with a url and template key: `{ url: 'http://example.com', template: 'index' }` |
 | options          | `object`           | `{}`                 | An object of [Critical](https://github.com/addyosmani/critical#options) options |

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ class Critical {
     register(config) {
         if (!config.urls || config.urls.length <= 0) {
             throw new Error(
-                'You need to provide at least 1 valid template with src and dest in the urls options.'
+                'You need to provide at least 1 valid url object containing both url and template keys.'
             );
         }
 


### PR DESCRIPTION
The URL option in the readme said to use: `src` & `dest`, instead of `url` & `template`.

I also removed the suffix "_critical.min.css" as it is hard coded, and updated the error message for when `config.urls` is empty.