### PR TITLE
Switched out html-critical-webpack-plugin package with critical-css-webpack-plugin (Means we are now using critical v4.0.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release notes for Laravel Mix Critical CSS
 
+## 2.0.0
+
+### Changed
+
+- Switched out html-critical-webpack-plugin package with critical-css-webpack-plugin, which mean we are now using latest version of critical.
+
 ## 1.0.1 
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -30,14 +30,21 @@ mix
         enabled: mix.inProduction(),
         paths: {
             base: 'https://url-of-where-criticalcss-is-extracted.com/',
-            templates: './where-critical-css-file-needs-to-be-written/',
+            templates: './css/critical', //Where css files need to be written, all these paths are relative to /public
+                                         //So the example path here will be public/css/critical       
             suffix: '_critical.min'
         },
         urls: [
             { url: 'blog', template: 'blog' },
         ],
+        //Now using https://github.com/addyosmani/critical v4.0.1
         options: {
-            minify: true,
+            //It's important to note here you should NOT set inline:true, this will break the whole system.
+            width:411,
+            height:823,
+            penthouse:{
+                timeout:1200000
+            }
         },
     });
 

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 const mix = require('laravel-mix');
+const merge = require('lodash/merge');
 
 class Critical {
     constructor() {
@@ -7,10 +8,10 @@ class Critical {
 
     dependencies() {
         this.requiresReload = `
-            HTML Webpack critical has been installed. Please run "npm run dev" again.
+            Critical-Css-Webpack-Plugin has been installed. Please run "npm run dev" again.
         `;
 
-        return ['html-critical-webpack-plugin'];
+        return ['critical-css-webpack-plugin'];
     }
 
     register(config) {
@@ -20,11 +21,13 @@ class Critical {
             );
         }
 
-        const critical = Object.assign({
+        const critical = merge({
             enabled: mix.inProduction(),
             paths: {},
             urls: [],
-            options: {},
+            options: {
+                inline:false
+            },
         }, config);
 
         if (critical.paths.suffix == null) critical.paths.suffix = '_critical.min';
@@ -34,14 +37,16 @@ class Critical {
 
     webpackPlugins() {
         if (this.criticals.map((e) => e.enabled).some(Boolean)) {
-            const HtmlCritical = require('html-critical-webpack-plugin');
+
+            const CriticalCssPlugin = require("critical-css-webpack-plugin");
+
             const plugins = [];
 
             this.criticals.forEach((critical) => {
 
                 critical.enabled && critical.urls.forEach((template) => {
                     const criticalSrc = critical.paths.base + template.url;
-                    const criticalDest = `${critical.paths.templates + template.template + critical.paths.suffix  }.css`;
+                    const criticalDest = `${critical.paths.templates + template.template + critical.paths.suffix}.css`;
 
                     if (criticalSrc.indexOf('amp_') !== -1) {
 
@@ -50,9 +55,9 @@ class Critical {
 
                     }
 
-                    plugins.push(new HtmlCritical(Object.assign({
+                    plugins.push(new CriticalCssPlugin(Object.assign({
                         src: criticalSrc,
-                        dest: criticalDest,
+                        target: criticalDest,
                     }, critical.options)));
                 });
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
   },
   "homepage": "https://github.com/dadamotion/laravel-mix-criticalcss#readme",
   "dependencies": {
-    "html-critical-webpack-plugin": "^2.1.0"
+    "critical-css-webpack-plugin": "^3.0.0",
+    "lodash": "^4.17.21"
   },
   "peerDependencies": {
     "laravel-mix": "^4.0.0 || ^5.0.0 || ^6.0.0"


### PR DESCRIPTION
Pretty much what it says in the title! Swapped out the older webpack plugin with a newer one. This seems to work for me on my fork and means we're now using the latest version of critical. 

Seems to address this issue: #11 

I've created a release for v2.0.0 as this strike me as a breaking change!

Happy to discuss :-).